### PR TITLE
[Feat] 월간 캘린더 디자인 수정 및 데이터 바인딩 함수 추가

### DIFF
--- a/Projects/App/Sources/Application/SceneDelegate.swift
+++ b/Projects/App/Sources/Application/SceneDelegate.swift
@@ -14,7 +14,7 @@ import Record
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
-    var coordinator: RecordCoordinator?
+    var coordinator: HomeCoordinator?//RecordCoordinator?
     
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
@@ -26,7 +26,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let navigationController = UINavigationController()
         navigationController.navigationBar.isHidden = true
         // RecordCoordinator 초기화 및 시작
-        coordinator = RecordCoordinator(navigationController: navigationController) //HomeCoordinator(navigationController: navigationController)
+        coordinator = HomeCoordinator(navigationController: navigationController) //RecordCoordinator(navigationController: navigationController)
         coordinator?.start()
         
         // UINavigationController를 루트로 설정

--- a/Projects/App/Sources/Test/CalenderView.swift
+++ b/Projects/App/Sources/Test/CalenderView.swift
@@ -1,0 +1,96 @@
+//
+//  CalenderView.swift
+//  App
+//
+//  Created by 박서연 on 2024/12/16.
+//  Copyright © 2024 inner-dev. All rights reserved.
+//
+
+import SwiftUI
+
+
+enum CalendarViewType {
+    case monthly
+    case weekly
+}
+
+struct CalenderView: View {
+    let monthly = CustomCalendarView(viewModel: CustomCalendarViewModel())
+    let weekly = WeeklyCalendarView(viewModel: CustomCalendarViewModel())
+    @State private var dragOffset: CGFloat = 0
+    @State private var currentView: CalendarViewType = .monthly
+    
+    var body: some View {
+        VStack {
+            switch currentView {
+            case .monthly:
+                VStack {
+                    monthly
+                    HStack {
+                        Spacer()
+                        Rectangle()
+                            .fill(.gray.opacity(0.4))
+                            .frame(width: 46, height: 4)
+                        Spacer()
+                    }
+                    .gesture(
+                        DragGesture()
+                            .onChanged { value in
+                                self.dragOffset = value.translation.height // 드래그 위치 업데이트
+                            }
+                            .onEnded { value in
+                                if abs(self.dragOffset) > 100 {
+                                    withAnimation {
+                                        self.currentView = .weekly
+                                    }
+                                }
+                            }
+                    )
+                }
+                
+            case .weekly:
+                VStack {
+                    HStack {
+                        Spacer()
+                        Rectangle()
+                            .fill(.gray.opacity(0.4))
+                            .frame(width: 46, height: 4)
+                        Spacer()
+                    }
+                    .gesture(
+                        DragGesture()
+                            .onChanged { value in
+                                self.dragOffset = value.translation.height // 드래그 위치 업데이트
+                            }
+                            .onEnded { value in
+                                if abs(self.dragOffset) > 100 {
+                                    withAnimation {
+                                        self.currentView = .monthly
+                                    }
+                                }
+                            }
+                    )
+                    weekly
+                }
+            }
+            
+            
+        }
+    }
+}
+struct WeeklyCalendarView: View {
+    let viewModel: CustomCalendarViewModel
+    var body: some View {
+        VStack {
+            Rectangle()
+                .fill(.pink)
+                .frame(height: 200)
+            Text("주간 캘린더")
+        }
+    }
+}
+
+
+#Preview {
+    CalenderView()
+}

--- a/Projects/App/Sources/Test/TestView.swift
+++ b/Projects/App/Sources/Test/TestView.swift
@@ -53,7 +53,7 @@ class CustomCalendarViewModel: ObservableObject {
 
 struct CustomCalendarView: View {
     @StateObject var viewModel = CustomCalendarViewModel()
-    
+    @State private var currentView: CalendarViewType = .monthly 
     @State var currentMonth = Date()
     @State var tappedDate: Date = Date()
     static let thisMonth = Date()
@@ -221,8 +221,7 @@ struct CustomCalendarView: View {
                     }
                 }
         )
-        .frame(height: 422)
-        .background(Color.white)
+        .background(Color.gray50)
     }
     
     func numberOfWeeks(in month: Date) -> Int {

--- a/Projects/Feature/Scene/Home/Sources/Calendar/CalendarHomeViewController.swift
+++ b/Projects/Feature/Scene/Home/Sources/Calendar/CalendarHomeViewController.swift
@@ -17,18 +17,37 @@ public class CalendarHomeViewController: UIViewController {
     private var mainEmotionComponent = MainEmotionViewComponent()
     private var aboutRecordComponent = HomeRecordViewComponent()
     private let viewModel = CustomCalendarViewModel()
-    private let containerView: UIStackView = {
+    
+    private let dateLabel: UILabel = {
+        let label = UILabel()
+        label.applyFontCase(.semibold(.footnote))
+        label.textColor = .gray700
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.backgroundColor = .backgroundColor
+        label.text = "2024.10.31일 감정기록"
+        return label
+    }()
+    
+    private let containerStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .horizontal
         stackView.spacing = 8
         stackView.distribution = .fillEqually
         stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.backgroundColor = .backgroundColor
         return stackView
+    }()
+    
+    let containView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = .backgroundColor
+        return view
     }()
     
     override public func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .backgroundColor
+        view.backgroundColor = .white
         setupCalendarView()
         setupNotificationObserver()
         setupComponent()
@@ -73,15 +92,27 @@ extension CalendarHomeViewController {
         mainEmotionComponent.translatesAutoresizingMaskIntoConstraints = false
         aboutRecordComponent.translatesAutoresizingMaskIntoConstraints = false
         
-        containerView.addArrangedSubview(mainEmotionComponent)
-        containerView.addArrangedSubview(aboutRecordComponent)
-        view.addSubview(containerView)
+        containerStackView.addArrangedSubview(mainEmotionComponent)
+        containerStackView.addArrangedSubview(aboutRecordComponent)
+        
+        containView.addSubview(dateLabel)
+        containView.addSubview(containerStackView)
+        view.addSubview(containView)
         
         NSLayoutConstraint.activate([
-            containerView.topAnchor.constraint(equalTo: hostingController.view.bottomAnchor, constant: 30),
-            containerView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 16),
-            containerView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -16),
-            containerView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -16),
+            containView.topAnchor.constraint(equalTo: hostingController.view.bottomAnchor),
+            containView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            containView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            containView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            
+            dateLabel.topAnchor.constraint(equalTo: containView.topAnchor, constant: 12),
+            dateLabel.leadingAnchor.constraint(equalTo: containView.leadingAnchor, constant: 16),
+            dateLabel.trailingAnchor.constraint(equalTo: containView.trailingAnchor, constant: -16),
+            
+            containerStackView.topAnchor.constraint(equalTo: dateLabel.bottomAnchor, constant: 12),
+            containerStackView.leadingAnchor.constraint(equalTo: containView.leadingAnchor, constant: 16),
+            containerStackView.trailingAnchor.constraint(equalTo: containView.trailingAnchor, constant: -16),
+            containerStackView.heightAnchor.constraint(equalToConstant: 219)
         ])
     }
 }

--- a/Projects/Feature/Scene/Home/Sources/Calendar/CalendarHomeViewController.swift
+++ b/Projects/Feature/Scene/Home/Sources/Calendar/CalendarHomeViewController.swift
@@ -24,7 +24,6 @@ public class CalendarHomeViewController: UIViewController {
         label.textColor = .gray700
         label.translatesAutoresizingMaskIntoConstraints = false
         label.backgroundColor = .backgroundColor
-        label.text = "2024.10.31일 감정기록"
         return label
     }()
     
@@ -51,6 +50,7 @@ public class CalendarHomeViewController: UIViewController {
         setupCalendarView()
         setupNotificationObserver()
         setupComponent()
+        bindingData()
     }
 
     private func setupCalendarView() {
@@ -114,5 +114,13 @@ extension CalendarHomeViewController {
             containerStackView.trailingAnchor.constraint(equalTo: containView.trailingAnchor, constant: -16),
             containerStackView.heightAnchor.constraint(equalToConstant: 219)
         ])
+    }
+}
+
+extension CalendarHomeViewController {
+    func bindingData() {
+        dateLabel.text = "\(viewModel.formattedDate())일 감정기록"
+        
+        mainEmotionComponent.updateData(emotion: "없어요", characterImage: .icSad, buttonTitle: "감정 기록하기", todayColor: .sad)
     }
 }

--- a/Projects/Feature/Scene/Home/Sources/Calendar/Component/HomeRecordViewComponent.swift
+++ b/Projects/Feature/Scene/Home/Sources/Calendar/Component/HomeRecordViewComponent.swift
@@ -28,6 +28,8 @@ public class HomeRecordViewComponent: UIView {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
         view.backgroundColor = .gray400
+        view.layer.cornerRadius = 3
+        view.clipsToBounds = true
         return view
     }()
     

--- a/Projects/Feature/Scene/Home/Sources/Calendar/Component/MainEmotionViewComponent.swift
+++ b/Projects/Feature/Scene/Home/Sources/Calendar/Component/MainEmotionViewComponent.swift
@@ -71,11 +71,11 @@ public class MainEmotionViewComponent: UIView {
     }()
 
     
-    private let emotionView: UIView = {
+    private let circleView: UIView = {
         let view = UIView()
         view.backgroundColor = .gray200
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.layer.cornerRadius = view.layer.bounds.width / 2
+        view.layer.cornerRadius = 3
         view.clipsToBounds = true
         return view
     }()
@@ -103,21 +103,18 @@ extension MainEmotionViewComponent {
 
 public extension MainEmotionViewComponent {
     func setupConstraints() {
-        addSubview(emotionView)
+        addSubview(circleView)
         addSubview(label)
         addSubview(mainEmotionLabel)
         addSubview(emotionButton)
         addSubview(emotionImage)
         
-        emotionView.layer.cornerRadius = emotionView.layer.bounds.width / 2
-        emotionView.clipsToBounds = true
-        
         NSLayoutConstraint.activate([
-            emotionView.topAnchor.constraint(equalTo: topAnchor, constant: 20),
-            emotionView.centerXAnchor.constraint(equalTo: centerXAnchor),
-            emotionView.widthAnchor.constraint(equalToConstant: 6),
-            emotionView.heightAnchor.constraint(equalToConstant: 6),
-            label.topAnchor.constraint(equalTo: emotionView.bottomAnchor, constant: 8),
+            circleView.topAnchor.constraint(equalTo: topAnchor, constant: 20),
+            circleView.centerXAnchor.constraint(equalTo: centerXAnchor),
+            circleView.widthAnchor.constraint(equalToConstant: 6),
+            circleView.heightAnchor.constraint(equalToConstant: 6),
+            label.topAnchor.constraint(equalTo: circleView.bottomAnchor, constant: 8),
             label.centerXAnchor.constraint(equalTo: centerXAnchor),
             mainEmotionLabel.topAnchor.constraint(equalTo: label.bottomAnchor, constant: 4),
             mainEmotionLabel.centerXAnchor.constraint(equalTo: centerXAnchor),

--- a/Projects/Feature/Scene/Home/Sources/Calendar/Component/MainEmotionViewComponent.swift
+++ b/Projects/Feature/Scene/Home/Sources/Calendar/Component/MainEmotionViewComponent.swift
@@ -102,7 +102,7 @@ extension MainEmotionViewComponent {
 }
 
 public extension MainEmotionViewComponent {
-    func setupConstraints() {
+    private func setupConstraints() {
         addSubview(circleView)
         addSubview(label)
         addSubview(mainEmotionLabel)
@@ -126,5 +126,18 @@ public extension MainEmotionViewComponent {
             emotionImage.widthAnchor.constraint(equalToConstant: 63),
             emotionImage.heightAnchor.constraint(equalToConstant: 63)
         ])
+    }
+    
+    func updateData(emotion: String, characterImage: UIImage, buttonTitle: String, todayColor: UIColor) {
+        circleView.backgroundColor = todayColor
+        mainEmotionLabel.text = emotion
+        emotionImage.image = characterImage
+        
+        // 버튼 제목 수정
+        guard var config = emotionButton.configuration else { return }
+        var title = AttributedString(buttonTitle)
+        title.font = FontCase.bold(.caption1).toUIFont
+        config.attributedTitle = title
+        emotionButton.configuration = config
     }
 }

--- a/Projects/Feature/Scene/Home/Sources/Calendar/Component/PastNoneRecordComponentView.swift
+++ b/Projects/Feature/Scene/Home/Sources/Calendar/Component/PastNoneRecordComponentView.swift
@@ -33,6 +33,8 @@ public class PastNoneRecordComponentView: UIView {
         let view = UIView()
         view.backgroundColor = .gray400
         view.translatesAutoresizingMaskIntoConstraints = false
+        view.layer.cornerRadius = 3
+        view.clipsToBounds = true
         return view
     }()
     

--- a/Projects/Feature/Scene/Home/Sources/Calendar/CustomCalendarView.swift
+++ b/Projects/Feature/Scene/Home/Sources/Calendar/CustomCalendarView.swift
@@ -12,7 +12,6 @@ import Combine
 
 struct CustomCalendarView: View {
     @ObservedObject var viewModel: CustomCalendarViewModel
-    let diaryData = DiaryData.sData
     
     private var preMonth: Date {
         return CustomCalendarViewModel.koreaCalendar.date(byAdding: .month, value: -1, to: viewModel.currentMonth)!
@@ -80,7 +79,7 @@ struct CustomCalendarView: View {
                     let calculatedDateComponent = Calendar.current.date(from: dateComponent) ?? Date()
                     let isToday = Calendar.current.isDateInToday(calculatedDateComponent)
                     let isPastDate = calculatedDateComponent < Calendar.current.startOfDay(for: Date())
-                    let isMatched = diaryData.contains { $0.createdDate == calculatedDateComponent }
+                    let isMatched = viewModel.diaryData.contains { $0.createdDate == calculatedDateComponent }
                     
                     VStack(spacing: 0) {
                         Circle()
@@ -121,8 +120,8 @@ struct CustomCalendarView: View {
                     .frame(height: 44)
                     .onTapGesture {
                         if isPastDate {
-                            print("date \(date)")
                             viewModel.tappedDiaryID = date
+                            viewModel.tappedDate = calculatedDateComponent
                         }
                     }
                     .background(viewModel.tappedDiaryID == date ? Color.coolgray50 : Color.clear)
@@ -157,7 +156,9 @@ extension Notification.Name {
 
 class CustomCalendarViewModel: ObservableObject {
     @Published var currentMonth: Date = Date()
+    @Published var tappedDate: Date = Date()
     @Published var tappedDiaryID: Int = 0
+    @Published var diaryData = DiaryData.sData
     
     var cancellables = Set<AnyCancellable>()
     
@@ -168,7 +169,6 @@ class CustomCalendarViewModel: ObservableObject {
         return current
     }()
     
-    // Date Formatters
     static let calendarHeaderDateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "ko_KR")
@@ -176,14 +176,12 @@ class CustomCalendarViewModel: ObservableObject {
         return formatter
     }()
     
-    // Short Weekday Symbols
     static let shortWeekly: [String] = {
         return koreaCalendar.shortWeekdaySymbols
     }()
     
-    // Helper Methods
     func formattedDate() -> String {
-        return Self.calendarHeaderDateFormatter.string(from: currentMonth)
+        return Self.calendarHeaderDateFormatter.string(from: tappedDate)
     }
     
     func firstDayOfMonth(_ date: Date) -> Int {

--- a/Projects/Feature/Scene/Home/Sources/Calendar/CustomCalendarView.swift
+++ b/Projects/Feature/Scene/Home/Sources/Calendar/CustomCalendarView.swift
@@ -84,14 +84,14 @@ struct CustomCalendarView: View {
                     
                     VStack(spacing: 0) {
                         Circle()
+                            .fill(Color.happy)
                             .frame(width: 4, height: 4)
                             .opacity(isMatched ? 1.0 : 0.0)
                         
                         if date <= 0 {
                             let preDate = viewModel.dateCount(preMonth) + date
-                            Text("\(preDate)")
-                                .foregroundStyle(date+viewModel.firstDayOfMonth(preMonth) == 1 ? .red : .black)
-                                .opacity(isPastDate ? 0.5 : 1.0)
+                            SText("\(preDate)", fontType: viewModel.tappedDiaryID == date ? .bold(.body) : .semibold(.body), color: date+viewModel.firstDayOfMonth(preMonth) == 1 ? .red : .black)
+                                .opacity(viewModel.tappedDiaryID == date ? 1.0 : (isPastDate ? 0.5 : 1.0))
                                 .frame(width: circleWidth, height: 40)
                             
                         } else if date > 0 && date <= viewModel.dateCount(viewModel.currentMonth) {
@@ -103,25 +103,29 @@ struct CustomCalendarView: View {
                                         Circle()
                                             .frame(width: circleWidth-8, height: 32)
                                             .overlay {
-                                                Text("\(date)")
-                                                    .foregroundStyle(Color.white)
+                                                SText("\(date)", fontType: .semibold(.body), color: .white)
                                             }
                                     }
                             } else {
-                                Text("\(date)")
-                                    .foregroundStyle(column ? Color.red : Color.black)
+                                SText("\(date)", fontType: viewModel.tappedDiaryID == date ? .bold(.body) : .semibold(.body), color: column ? Color.red : Color.black)
                                     .frame(width: circleWidth, height: 40)
-                                    .opacity(isPastDate ? 0.5 : 1.0)
+                                    .opacity(viewModel.tappedDiaryID == date ? 1.0 : (isPastDate ? 0.5 : 1.0))
                             }
                         } else {
                             let nextMonthDay = date - viewModel.dateCount(viewModel.currentMonth)
-                            Text("\(nextMonthDay)")
-                                .foregroundStyle(column ? Color.red : Color.black)
+                            SText("\(nextMonthDay)", fontType: viewModel.tappedDiaryID == date ? .bold(.body) : .semibold(.body), color: column ? Color.red : Color.black)
                                 .frame(width: circleWidth, height: 40)
                                 .opacity(isPastDate ? 0.5 : 1.0)
                         }
                     }
                     .frame(height: 44)
+                    .onTapGesture {
+                        if isPastDate {
+                            print("date \(date)")
+                            viewModel.tappedDiaryID = date
+                        }
+                    }
+                    .background(viewModel.tappedDiaryID == date ? Color.coolgray50 : Color.clear)
                 }
             }
             .padding(.horizontal, 8)
@@ -153,7 +157,7 @@ extension Notification.Name {
 
 class CustomCalendarViewModel: ObservableObject {
     @Published var currentMonth: Date = Date()
-    @Published var tappedDate: Date = Date()
+    @Published var tappedDiaryID: Int = 0
     
     var cancellables = Set<AnyCancellable>()
     
@@ -226,6 +230,7 @@ class CustomCalendarViewModel: ObservableObject {
     
     func goToToday() {
         currentMonth = Date()
+        tappedDiaryID = 0
     }
 }
 
@@ -263,5 +268,7 @@ struct DiaryData {
         .init(id: 0, primaryEmotion: "HAPPY", createdAt: "2024-12-01T14:19:01.273Z"),
         .init(id: 0, primaryEmotion: "HAPPY", createdAt: "2024-12-03T14:19:01.273Z"),
         .init(id: 0, primaryEmotion: "HAPPY", createdAt: "2024-12-04T14:19:01.273Z"),
+        .init(id: 0, primaryEmotion: "HAPPY", createdAt: "2024-12-15T14:19:01.273Z"),
+        .init(id: 0, primaryEmotion: "HAPPY", createdAt: "2024-12-12T14:19:01.273Z"),
     ]
 }


### PR DESCRIPTION
## [Feat] 월간 캘린더 디자인 수정 및 데이터 바인딩 함수 추가

### 구현내용
- #9 
- 월간 캘린더 tappedDate에 배경색 추가
- 미래 날짜 tapped disable 설정 추가
- 하위 기록 유무 / 메인 감정 컴포넌트 관련 데이터 바인딩 함수 추가

### TODO(미구현/추후구현)
- Monthly Calendar 날짜 계산 로직 VM으로 분리 후 네트워크랑 연결 예정
